### PR TITLE
Links fixed in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The research and development is being done by the Natural Language Processing
 group at UCLA led by David Jurgens and Keith Stevens, under the advisory of Dr.
 Michael Dyer.
 
-See the [Getting Started](wiki/GettingStarted) page for
+See the [Getting Started](../../wiki/GettingStarted) page for
 a quick introduction on how to use the S-Space package, see the [Package
-Overview](wiki/PackageLayout) for information on the
+Overview](../../wiki/PackageLayout) for information on the
 code and available features, or dive right into the
 [Javadoc](http://fozziethebeat.github.com/S-Space/apidocs/) to see what's
 available now.  For any questions, please contact us via our mailing lists:


### PR DESCRIPTION
Original links of "Get Started" and "Package Overview" were not existed. 
The readme.md file is in /S-Space/blob/master/ ,not /S-Space/. The relative links to wiki should go two directories level up.
