### PR TITLE
Setting `inputFormat` to TEXT or SPARSE_TEXT doesn't write to file (Hadoop RI)

### DIFF
--- a/hadoop/src/main/java/edu/ucla/sspace/ri/HadoopRandomIndexing.java
+++ b/hadoop/src/main/java/edu/ucla/sspace/ri/HadoopRandomIndexing.java
@@ -363,6 +363,11 @@ public class HadoopRandomIndexing {
                 semantics = createSemanticVector();
             }
 
+            // Check if this is the last word, if yes then write
+            if(!occurrences.hasNext()) {
+                writer.write(curWord, semantics);
+            }
+
             // NOTE: because we are using a GeneratorMap, this call will create
             // a new index vector for the word if it didn't exist prior.
             TernaryVector indexVector = 

--- a/src/main/java/edu/ucla/sspace/common/SemanticSpaceWriter.java
+++ b/src/main/java/edu/ucla/sspace/common/SemanticSpaceWriter.java
@@ -194,6 +194,7 @@ public class SemanticSpaceWriter {
                 }
             }
             pw.println(sb.toString());
+            pw.flush();
             break;
         }
             
@@ -202,6 +203,7 @@ public class SemanticSpaceWriter {
         case TEXT: {
             PrintWriter pw = new PrintWriter(writer);
             pw.println(word + "|" + VectorIO.toString(vector));
+            pw.flush();
             break;
         }
 
@@ -270,6 +272,7 @@ public class SemanticSpaceWriter {
             String blankStr = new String(blanks);
             PrintWriter pw = new PrintWriter(writer);
             pw.println(blankStr);
+            pw.flush();
             break;
         case BINARY: 
         case SPARSE_BINARY:


### PR DESCRIPTION
There are two bugs when running the Hadoop RI. 
1. Whenever the supplied `--inputFormat` is either `TEXT` or `SPARSE_TEXT`. Somehow, the buffer didn't get flushed even on `close()`. So, I manually flush the buffer everytime it is calling the write method. It is also not flushing the buffer when writing the header of file (called during `writeEmptyHeader()`)
2. There is logic error when iterating each occurrences of word. It caused the last occurrence of word to not be printed. i.e. If my document is `you know nothing Jon Snow`, it writes the vector for all except the last word `Snow`. Not necessarily the last word in the sentence though, depends how it got sorted during mapper-reducer phase, but one of the words will definitely be missing when writing to file.

Anyway, thanks for the great package!
