### PR TITLE
In Basis maker, the process document function would only process tokens ...

### DIFF
--- a/src/main/java/edu/ucla/sspace/tools/BasisMaker.java
+++ b/src/main/java/edu/ucla/sspace/tools/BasisMaker.java
@@ -212,7 +212,7 @@ public class BasisMaker extends GenericMain {
 
                 // If the filter does not accept this word, skip the semantic
                 // processing, continue with the next word
-                if (focus.equals(IteratorFactory.EMPTY_TOKEN)) {
+                if (!focus.equals(IteratorFactory.EMPTY_TOKEN)) {
                     int focusIndex = basis.getDimension(focus);
                     
                     countOccurrences(nextWords, focusIndex,


### PR DESCRIPTION
...which should be skipped according to the tokenizer. This is due to checking that the token equals the empty_token rather than not equals.