### PR TITLE
Fix #69.

### DIFF
--- a/src/main/java/edu/ucla/sspace/common/DocumentVectorBuilder.java
+++ b/src/main/java/edu/ucla/sspace/common/DocumentVectorBuilder.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 
 /**
@@ -125,11 +126,18 @@ public class DocumentVectorBuilder {
 
         // Iterate through each term in the document and sum the term Vectors 
         // found in the provided SemanticSpace.
+        // If the underlying BasisMapping of the sspace is not read-only, then
+        // the getVector method would try to access a non-existing element. 
+        // We therefore check here if the word is in the mapping and
+        // skip the word if it is not.
+        Set<String> knownWords = sspace.getWords();
         for (Map.Entry<String, Integer> entry : termCounts.entrySet()) {
-            Vector termVector = sspace.getVector(entry.getKey());
-            if (termVector == null)
-                continue;
-            add(documentVector, termVector, entry.getValue());
+            if(knownWords.contains(entry.getKey())) {
+              Vector termVector = sspace.getVector(entry.getKey());
+              if (termVector == null)
+                  continue;
+              add(documentVector, termVector, entry.getValue());
+            }
         }
 
         return documentVector;


### PR DESCRIPTION
Fix issue #69 as described there: prevent making sspace to look up a non-existing word and throw an exception by first explicitly checking if the word is in the set of known words.
There may be other ways to fix this which would involve exposing the readOnly status of the basis mapping inside the ssapce, making it possible to change that status or similar.